### PR TITLE
fix: set sentry env in github workflow

### DIFF
--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -14,3 +14,5 @@ jobs:
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/fly.yaml` file. The change adds environment variables for Sentry integration to the deployment job.

* [`.github/workflows/fly.yaml`](diffhunk://#diff-a458804ceefe373c93cee3f81d5a79277f268891fdc59ea7b07d9d6ea7a42a0bR17-R18): Added `SENTRY_ORG` and `SENTRY_AUTH_TOKEN` environment variables to the `flyctl deploy` step.