### PR TITLE
build: add secret mounts for Sentry integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ COPY gradlew .
 COPY build.gradle .
 COPY settings.gradle .
 
-RUN ./gradlew --no-daemon dependencies
+RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
+    --mount=type=secret,id=SENTRY_ORG \
+    ./gradlew --no-daemon dependencies
 
 COPY src src
 


### PR DESCRIPTION
This pull request includes an important change to the `Dockerfile` to enhance security by using secret mounts for sensitive information.

Security improvements:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L10-R12): Modified the `RUN ./gradlew --no-daemon dependencies` command to use secret mounts for `SENTRY_AUTH_TOKEN` and `SENTRY_ORG` to ensure sensitive information is not exposed.